### PR TITLE
fix: nekoton_bridge should depend on build_runner

### DIFF
--- a/packages/nekoton_bridge/pubspec.yaml
+++ b/packages/nekoton_bridge/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 #   path: ^1.8.0
 
 dev_dependencies:
+  build_runner: ^2.3.3
   ffigen: ^7.2.4
   lints: ^2.0.0
   test: ^1.16.0


### PR DESCRIPTION
There is a related bug: https://github.com/fzyzcjy/flutter_rust_bridge/issues/1073#issuecomment-1438442129