### PR TITLE
fix: rust warings and build script

### DIFF
--- a/packages/nekoton_bridge/bin/merger.dart
+++ b/packages/nekoton_bridge/bin/merger.dart
@@ -90,22 +90,26 @@ void main() async {
 /// `pub use crate::nekoton_wrapper::{MnemonicType, dict};
 void parseSingleImport(String importFull, Map<String, ModuleHierarchy> crates) {
   final importStr = importFull.replaceAll(RegExp('.*use '), '');
-  parseImports(importStr, crates, isRoot: true, isRootPublic: importFull.startsWith('pub'));
+  parseImports(importStr, crates,
+      isRoot: true, isRootPublic: importFull.startsWith('pub'));
 }
 
 /// Convert resulted [hierarchy] to single string with all nested sub-modules.
-void convertCrateToString(Map<String, ModuleHierarchy> hierarchy, StringBuffer buffer) {
+void convertCrateToString(
+    Map<String, ModuleHierarchy> hierarchy, StringBuffer buffer) {
   hierarchy.forEach((moduleName, hierarchy) {
     buffer.write(
       '${hierarchy.isRootPublic ? 'pub ' : ''}${hierarchy.isRoot ? 'use ' : ''}$moduleName::{',
     );
-    if (hierarchy.directImports.isNotEmpty && hierarchy.directImports.contains('*')) {
+    if (hierarchy.directImports.isNotEmpty &&
+        hierarchy.directImports.contains('*')) {
       buffer.write('*');
     } else {
       buffer.write('\n');
     }
 
-    if (hierarchy.directImports.isNotEmpty && !hierarchy.directImports.contains('*')) {
+    if (hierarchy.directImports.isNotEmpty &&
+        !hierarchy.directImports.contains('*')) {
       buffer.write('${hierarchy.directImports.join(',')},\n');
     }
 
@@ -136,13 +140,15 @@ void parseImports(
   }
 
   // pure name line nekoton_wrapper or models_api
-  final moduleName = croppedCrate.substring(0, croppedCrate.indexOf('::')).trim();
+  final moduleName =
+      croppedCrate.substring(0, croppedCrate.indexOf('::')).trim();
 
   // skip *api files because they will be merged
   if (moduleName.endsWith('api')) return;
 
   if (!hierarchy.containsKey(moduleName)) {
-    hierarchy[moduleName] = ModuleHierarchy(moduleName: moduleName, isRoot: isRoot);
+    hierarchy[moduleName] =
+        ModuleHierarchy(moduleName: moduleName, isRoot: isRoot);
   }
 
   /// Works only for root
@@ -155,7 +161,8 @@ void parseImports(
 
   final doubleDotIndex = croppedCrate.indexOf('::');
   final bracketIndex = croppedCrate.indexOf('{');
-  if (doubleDotIndex != -1 && (bracketIndex == -1 || doubleDotIndex < bracketIndex)) {
+  if (doubleDotIndex != -1 &&
+      (bracketIndex == -1 || doubleDotIndex < bracketIndex)) {
     // more module names here, add in loop sub modules
     parseImports(croppedCrate, hierarchy[moduleName]!.subModules);
   } else if (bracketIndex == 0) {
@@ -176,7 +183,8 @@ void parseImports(
 
           /// Iterate over all 'crate spaces' and run parser for each of them
           cratesInSingleLineSpaceReg.allMatches(cratesGroup).forEach((crate) {
-            final crateStr = cratesGroup.substring(startOfCrate, crate.start + 1);
+            final crateStr =
+                cratesGroup.substring(startOfCrate, crate.start + 1);
             startOfCrate = crate.start + 2;
             parseImports(crateStr, hierarchy[moduleName]!.subModules);
           });

--- a/packages/nekoton_bridge/native/Cargo.toml
+++ b/packages/nekoton_bridge/native/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["staticlib", "cdylib"]
 
 [build-dependencies]
 flutter_rust_bridge_codegen = "1.66.*"
+rerun_except = "1.0.0"
 
 [dependencies]
 flutter_rust_bridge = "1.66.*"

--- a/packages/nekoton_bridge/native/build.rs
+++ b/packages/nekoton_bridge/native/build.rs
@@ -1,6 +1,7 @@
 use lib_flutter_rust_bridge_codegen::{
     config_parse, frb_codegen, get_symbols_if_no_duplicates, RawOpts,
 };
+use rerun_except::rerun_except;
 
 const RUST_INPUT: &str = "src/merged.rs";
 const DART_OUTPUT: &str = "../lib/src/bridge_generated.dart";
@@ -9,7 +10,7 @@ const IOS_C_OUTPUT: &str = "../../flutter_nekoton_bridge/ios/Classes/frb.h";
 
 fn main() {
     // Tell Cargo that if the input Rust code changes, rerun this build script
-    println!("cargo:rerun_except={RUST_INPUT}");
+    rerun_except(&["**/*_api.rs"]).unwrap();
 
     // Create merged file for generation
     let mut codegen = std::process::Command::new("dart")

--- a/packages/nekoton_bridge/native/src/nekoton_wrapper/crypto/derived_key/derived_key_api.rs
+++ b/packages/nekoton_bridge/native/src/nekoton_wrapper/crypto/derived_key/derived_key_api.rs
@@ -1,1 +1,2 @@
+#![allow(unused_variables, dead_code)]
 pub const DERIVED_KEY_SIGNER_NAME: &str = "DerivedKeySigner";

--- a/packages/nekoton_bridge/native/src/nekoton_wrapper/crypto/encrypted_key/encrypted_key_api.rs
+++ b/packages/nekoton_bridge/native/src/nekoton_wrapper/crypto/encrypted_key/encrypted_key_api.rs
@@ -1,3 +1,5 @@
+#![allow(unused_variables, dead_code)]
+
 pub use nekoton::crypto::MnemonicType;
 
 pub const ENCRYPTED_KEY_SIGNER_NAME: &str = "EncryptedKeySigner";

--- a/packages/nekoton_bridge/native/src/nekoton_wrapper/crypto/ledger_key/ledger_api.rs
+++ b/packages/nekoton_bridge/native/src/nekoton_wrapper/crypto/ledger_key/ledger_api.rs
@@ -1,1 +1,3 @@
+#![allow(unused_variables, dead_code)]
+
 pub const LEDGER_KEY_SIGNER_NAME: &str = "LedgerKeySigner";

--- a/packages/nekoton_bridge/native/src/nekoton_wrapper/crypto/mnemonic/mnemonic_api.rs
+++ b/packages/nekoton_bridge/native/src/nekoton_wrapper/crypto/mnemonic/mnemonic_api.rs
@@ -1,3 +1,5 @@
+#![allow(unused_variables, dead_code)]
+
 use nekoton::crypto::{derive_from_phrase, dict, generate_key};
 
 use crate::nekoton_wrapper::{

--- a/packages/nekoton_bridge/native/src/nekoton_wrapper/mod.rs
+++ b/packages/nekoton_bridge/native/src/nekoton_wrapper/mod.rs
@@ -1,11 +1,8 @@
 pub mod crypto;
 pub mod models_api;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use serde::Serialize;
-use ton_block::MsgAddressInt;
-
-use std::str::FromStr;
 
 #[macro_export]
 macro_rules! clock {
@@ -38,7 +35,7 @@ where
             Err(err) => ExecutionResult::Err(err),
         };
 
-        serde_json::to_string(&result).unwrap().to_string()
+        serde_json::to_string(&result).unwrap()
     }
 }
 
@@ -60,19 +57,19 @@ where
     }
 }
 
-fn parse_hash(hash: String) -> Result<ton_types::UInt256, String> {
-    ton_types::UInt256::from_str(hash.as_str()).handle_error()
-}
+// fn parse_hash(hash: String) -> Result<ton_types::UInt256, String> {
+//     ton_types::UInt256::from_str(hash.as_str()).handle_error()
+// }
 
-fn parse_public_key(public_key: String) -> Result<ed25519_dalek::PublicKey, anyhow::Error> {
-    Ok(ed25519_dalek::PublicKey::from_bytes(
-        &hex::decode(public_key.as_str()).context("Bad hex data")?,
-    )?)
-}
+// fn parse_public_key(public_key: String) -> Result<ed25519_dalek::PublicKey, anyhow::Error> {
+//     Ok(ed25519_dalek::PublicKey::from_bytes(
+//         &hex::decode(public_key.as_str()).context("Bad hex data")?,
+//     )?)
+// }
 
-fn parse_address(address: String) -> Result<MsgAddressInt, String> {
-    MsgAddressInt::from_str(address.as_str()).handle_error()
-}
+// fn parse_address(address: String) -> Result<MsgAddressInt, String> {
+//     MsgAddressInt::from_str(address.as_str()).handle_error()
+// }
 
 pub(crate) fn str_list_to_string_vec(slice: &[&str]) -> Vec<String> {
     slice.into_iter().map(|x| x.to_string()).collect()

--- a/packages/nekoton_bridge/native/src/nekoton_wrapper/models_api.rs
+++ b/packages/nekoton_bridge/native/src/nekoton_wrapper/models_api.rs
@@ -1,3 +1,5 @@
+#![allow(unused_variables, dead_code)]
+
 use flutter_rust_bridge::frb;
 pub use nekoton::crypto::MnemonicType;
 

--- a/packages/nekoton_bridge/native/src/utils/api.rs
+++ b/packages/nekoton_bridge/native/src/utils/api.rs
@@ -1,4 +1,4 @@
-#![allow(unused_variables)]
+#![allow(unused_variables, dead_code)]
 
 use flutter_rust_bridge::*;
 use log::*;

--- a/packages/nekoton_bridge/test/merger_hierarchy_parse_test.dart
+++ b/packages/nekoton_bridge/test/merger_hierarchy_parse_test.dart
@@ -23,13 +23,19 @@ void main() {
       expect(nekotonCrate.subModules.keys.toSet(), {'crypto'});
       expect(
         nekotonCrate.directImports,
-        {'str_list_to_string_vec', 'str_vec_to_string_vec', 'HandleError', 'MatchResult'},
+        {
+          'str_list_to_string_vec',
+          'str_vec_to_string_vec',
+          'HandleError',
+          'MatchResult'
+        },
       );
 
       final cryptoModule = nekotonCrate.subModules['crypto']!;
       expect(cryptoModule.directImports.isEmpty, true);
       expect(
-        cryptoModule.subModules['mnemonic']!.subModules['models']!.directImports,
+        cryptoModule
+            .subModules['mnemonic']!.subModules['models']!.directImports,
         {'KeypairHelper'},
       );
     });
@@ -54,13 +60,19 @@ void main() {
       expect(nekotonCrate.subModules.keys.toSet(), {'crypto'});
       expect(
         nekotonCrate.directImports,
-        {'str_list_to_string_vec', 'str_vec_to_string_vec', 'HandleError', 'MatchResult'},
+        {
+          'str_list_to_string_vec',
+          'str_vec_to_string_vec',
+          'HandleError',
+          'MatchResult'
+        },
       );
 
       final cryptoModule = nekotonCrate.subModules['crypto']!;
       expect(cryptoModule.directImports.isEmpty, true);
       expect(
-        cryptoModule.subModules['mnemonic']!.subModules['models']!.directImports,
+        cryptoModule
+            .subModules['mnemonic']!.subModules['models']!.directImports,
         {'KeypairHelper'},
       );
     });
@@ -147,14 +159,16 @@ void main() {
       expect(nekotonCrate.directImports.length, 0);
       final cryptoCrate = nekotonCrate.subModules['crypto']!;
       expect(cryptoCrate.subModules.length, 0);
-      expect(cryptoCrate.directImports, {'dict', 'derive_from_phrase', 'generate_key'});
+      expect(cryptoCrate.directImports,
+          {'dict', 'derive_from_phrase', 'generate_key'});
       expect(cryptoCrate.moduleName, 'crypto');
     });
   });
 
   group('Test hierarchy converting to string', () {
     test('Convert plain hierarchy not public', () {
-      final nekoton = ModuleHierarchy(moduleName: 'nekoton_wrapper', isRoot: false);
+      final nekoton =
+          ModuleHierarchy(moduleName: 'nekoton_wrapper', isRoot: false);
       nekoton.directImports.add('SomeModule');
       final crate = ModuleHierarchy(moduleName: 'crate', isRoot: true);
       crate.subModules['nekoton_wrapper'] = nekoton;
@@ -175,7 +189,8 @@ SomeModule,
     });
 
     test('Convert plain hierarchy public', () {
-      final nekoton = ModuleHierarchy(moduleName: 'nekoton_wrapper', isRoot: false);
+      final nekoton =
+          ModuleHierarchy(moduleName: 'nekoton_wrapper', isRoot: false);
       nekoton.directImports.add('SomeModule');
       final crate = ModuleHierarchy(moduleName: 'crate', isRoot: true);
       crate.subModules['nekoton_wrapper'] = nekoton;
@@ -207,7 +222,8 @@ SomeModule,
       final models = ModuleHierarchy(moduleName: 'models', isRoot: false);
       models.directImports.add('ModelType');
 
-      final nekoton = ModuleHierarchy(moduleName: 'nekoton_wrapper', isRoot: false);
+      final nekoton =
+          ModuleHierarchy(moduleName: 'nekoton_wrapper', isRoot: false);
       nekoton.directImports.add('SomeType');
       nekoton.subModules['crypto'] = crypto;
       nekoton.subModules['models'] = models;


### PR DESCRIPTION
Fix some rust warnings, added rerun_except cargo (test need!). Also, we should fix some rust-related shings (just run melos check-all, or, especially, melos check-rust):
error: redundant clone
  --> packages/nekoton_bridge/native/src/nekoton_wrapper/mod.rs:38:48
   |
38 |         serde_json::to_string(&result).unwrap().to_string()
   |                                                ^^^^^^^^^^^^ help: remove this
   |
note: this value is dropped without further use
  --> packages/nekoton_bridge/native/src/nekoton_wrapper/mod.rs:38:9
   |
38 |         serde_json::to_string(&result).unwrap().to_string()
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone
   = note: `-D clippy::redundant-clone` implied by `-D warnings`



error: this `.into_iter()` call is equivalent to `.iter()` and will not consume the `slice`
  --> packages/nekoton_bridge/native/src/nekoton_wrapper/mod.rs:75:11
   |
75 |     slice.into_iter().map(|x| x.to_string()).collect()
   |           ^^^^^^^^^ help: call directly: `iter`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#into_iter_on_ref
   = note: `-D clippy::into-iter-on-ref` implied by `-D warnings` 