### PR TITLE
fix(EWM-508): add NotExistingContract model to fix broken contract state

### DIFF
--- a/packages/flutter_nekoton_bridge/lib/nekoton/core/models/not_existing_contract.dart
+++ b/packages/flutter_nekoton_bridge/lib/nekoton/core/models/not_existing_contract.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:flutter_nekoton_bridge/nekoton/core/models/gen_timings.dart';
+
+part 'not_existing_contract.freezed.dart';
+part 'not_existing_contract.g.dart';
+
+@freezed
+sealed class NotExistingContract with _$NotExistingContract {
+  const factory NotExistingContract({
+    required final GenTimings timings,
+  }) = _NotExistingContract;
+
+  factory NotExistingContract.fromJson(Map<String, dynamic> json) =>
+      _$NotExistingContractFromJson(json);
+}

--- a/packages/flutter_nekoton_bridge/lib/nekoton/core/models/not_existing_contract.freezed.dart
+++ b/packages/flutter_nekoton_bridge/lib/nekoton/core/models/not_existing_contract.freezed.dart
@@ -1,0 +1,186 @@
+// dart format width=80
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'not_existing_contract.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$NotExistingContract {
+  GenTimings get timings;
+
+  /// Create a copy of NotExistingContract
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $NotExistingContractCopyWith<NotExistingContract> get copyWith =>
+      _$NotExistingContractCopyWithImpl<NotExistingContract>(
+          this as NotExistingContract, _$identity);
+
+  /// Serializes this NotExistingContract to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is NotExistingContract &&
+            (identical(other.timings, timings) || other.timings == timings));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, timings);
+
+  @override
+  String toString() {
+    return 'NotExistingContract(timings: $timings)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $NotExistingContractCopyWith<$Res> {
+  factory $NotExistingContractCopyWith(
+          NotExistingContract value, $Res Function(NotExistingContract) _then) =
+      _$NotExistingContractCopyWithImpl;
+  @useResult
+  $Res call({GenTimings timings});
+
+  $GenTimingsCopyWith<$Res> get timings;
+}
+
+/// @nodoc
+class _$NotExistingContractCopyWithImpl<$Res>
+    implements $NotExistingContractCopyWith<$Res> {
+  _$NotExistingContractCopyWithImpl(this._self, this._then);
+
+  final NotExistingContract _self;
+  final $Res Function(NotExistingContract) _then;
+
+  /// Create a copy of NotExistingContract
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? timings = null,
+  }) {
+    return _then(_self.copyWith(
+      timings: null == timings
+          ? _self.timings
+          : timings // ignore: cast_nullable_to_non_nullable
+              as GenTimings,
+    ));
+  }
+
+  /// Create a copy of NotExistingContract
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $GenTimingsCopyWith<$Res> get timings {
+    return $GenTimingsCopyWith<$Res>(_self.timings, (value) {
+      return _then(_self.copyWith(timings: value));
+    });
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _NotExistingContract implements NotExistingContract {
+  const _NotExistingContract({required this.timings});
+  factory _NotExistingContract.fromJson(Map<String, dynamic> json) =>
+      _$NotExistingContractFromJson(json);
+
+  @override
+  final GenTimings timings;
+
+  /// Create a copy of NotExistingContract
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$NotExistingContractCopyWith<_NotExistingContract> get copyWith =>
+      __$NotExistingContractCopyWithImpl<_NotExistingContract>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$NotExistingContractToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _NotExistingContract &&
+            (identical(other.timings, timings) || other.timings == timings));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, timings);
+
+  @override
+  String toString() {
+    return 'NotExistingContract(timings: $timings)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$NotExistingContractCopyWith<$Res>
+    implements $NotExistingContractCopyWith<$Res> {
+  factory _$NotExistingContractCopyWith(_NotExistingContract value,
+          $Res Function(_NotExistingContract) _then) =
+      __$NotExistingContractCopyWithImpl;
+  @override
+  @useResult
+  $Res call({GenTimings timings});
+
+  @override
+  $GenTimingsCopyWith<$Res> get timings;
+}
+
+/// @nodoc
+class __$NotExistingContractCopyWithImpl<$Res>
+    implements _$NotExistingContractCopyWith<$Res> {
+  __$NotExistingContractCopyWithImpl(this._self, this._then);
+
+  final _NotExistingContract _self;
+  final $Res Function(_NotExistingContract) _then;
+
+  /// Create a copy of NotExistingContract
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? timings = null,
+  }) {
+    return _then(_NotExistingContract(
+      timings: null == timings
+          ? _self.timings
+          : timings // ignore: cast_nullable_to_non_nullable
+              as GenTimings,
+    ));
+  }
+
+  /// Create a copy of NotExistingContract
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $GenTimingsCopyWith<$Res> get timings {
+    return $GenTimingsCopyWith<$Res>(_self.timings, (value) {
+      return _then(_self.copyWith(timings: value));
+    });
+  }
+}
+
+// dart format on

--- a/packages/flutter_nekoton_bridge/lib/nekoton/core/models/not_existing_contract.g.dart
+++ b/packages/flutter_nekoton_bridge/lib/nekoton/core/models/not_existing_contract.g.dart
@@ -1,0 +1,18 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'not_existing_contract.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_NotExistingContract _$NotExistingContractFromJson(Map<String, dynamic> json) =>
+    _NotExistingContract(
+      timings: GenTimings.fromJson(json['timings'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$NotExistingContractToJson(
+        _NotExistingContract instance) =>
+    <String, dynamic>{
+      'timings': instance.timings.toJson(),
+    };

--- a/packages/flutter_nekoton_bridge/lib/nekoton/core/models/raw_contract_state.dart
+++ b/packages/flutter_nekoton_bridge/lib/nekoton/core/models/raw_contract_state.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_nekoton_bridge/nekoton/core/models/not_existing_contract.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:flutter_nekoton_bridge/flutter_nekoton_bridge.dart';
 
@@ -6,7 +7,7 @@ part 'raw_contract_state.g.dart';
 
 @Freezed(unionKey: 'type')
 sealed class RawContractState with _$RawContractState {
-  const factory RawContractState.notExists(GenTimings timings) =
+  const factory RawContractState.notExists(NotExistingContract data) =
       RawContractStateNotExists;
 
   const factory RawContractState.exists(ExistingContract data) =

--- a/packages/flutter_nekoton_bridge/lib/nekoton/core/models/raw_contract_state.freezed.dart
+++ b/packages/flutter_nekoton_bridge/lib/nekoton/core/models/raw_contract_state.freezed.dart
@@ -27,22 +27,27 @@ RawContractState _$RawContractStateFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$RawContractState {
+  Object get data;
+
   /// Serializes this RawContractState to a JSON map.
   Map<String, dynamic> toJson();
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
-        (other.runtimeType == runtimeType && other is RawContractState);
+        (other.runtimeType == runtimeType &&
+            other is RawContractState &&
+            const DeepCollectionEquality().equals(other.data, data));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => runtimeType.hashCode;
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(data));
 
   @override
   String toString() {
-    return 'RawContractState()';
+    return 'RawContractState(data: $data)';
   }
 }
 
@@ -55,12 +60,13 @@ class $RawContractStateCopyWith<$Res> {
 /// @nodoc
 @JsonSerializable()
 class RawContractStateNotExists implements RawContractState {
-  const RawContractStateNotExists(this.timings, {final String? $type})
+  const RawContractStateNotExists(this.data, {final String? $type})
       : $type = $type ?? 'notExists';
   factory RawContractStateNotExists.fromJson(Map<String, dynamic> json) =>
       _$RawContractStateNotExistsFromJson(json);
 
-  final GenTimings timings;
+  @override
+  final NotExistingContract data;
 
   @JsonKey(name: 'type')
   final String $type;
@@ -85,16 +91,16 @@ class RawContractStateNotExists implements RawContractState {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is RawContractStateNotExists &&
-            (identical(other.timings, timings) || other.timings == timings));
+            (identical(other.data, data) || other.data == data));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(runtimeType, timings);
+  int get hashCode => Object.hash(runtimeType, data);
 
   @override
   String toString() {
-    return 'RawContractState.notExists(timings: $timings)';
+    return 'RawContractState.notExists(data: $data)';
   }
 }
 
@@ -105,9 +111,9 @@ abstract mixin class $RawContractStateNotExistsCopyWith<$Res>
           $Res Function(RawContractStateNotExists) _then) =
       _$RawContractStateNotExistsCopyWithImpl;
   @useResult
-  $Res call({GenTimings timings});
+  $Res call({NotExistingContract data});
 
-  $GenTimingsCopyWith<$Res> get timings;
+  $NotExistingContractCopyWith<$Res> get data;
 }
 
 /// @nodoc
@@ -122,13 +128,13 @@ class _$RawContractStateNotExistsCopyWithImpl<$Res>
   /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   $Res call({
-    Object? timings = null,
+    Object? data = null,
   }) {
     return _then(RawContractStateNotExists(
-      null == timings
-          ? _self.timings
-          : timings // ignore: cast_nullable_to_non_nullable
-              as GenTimings,
+      null == data
+          ? _self.data
+          : data // ignore: cast_nullable_to_non_nullable
+              as NotExistingContract,
     ));
   }
 
@@ -136,9 +142,9 @@ class _$RawContractStateNotExistsCopyWithImpl<$Res>
   /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
-  $GenTimingsCopyWith<$Res> get timings {
-    return $GenTimingsCopyWith<$Res>(_self.timings, (value) {
-      return _then(_self.copyWith(timings: value));
+  $NotExistingContractCopyWith<$Res> get data {
+    return $NotExistingContractCopyWith<$Res>(_self.data, (value) {
+      return _then(_self.copyWith(data: value));
     });
   }
 }
@@ -151,6 +157,7 @@ class RawContractStateExists implements RawContractState {
   factory RawContractStateExists.fromJson(Map<String, dynamic> json) =>
       _$RawContractStateExistsFromJson(json);
 
+  @override
   final ExistingContract data;
 
   @JsonKey(name: 'type')

--- a/packages/flutter_nekoton_bridge/lib/nekoton/core/models/raw_contract_state.g.dart
+++ b/packages/flutter_nekoton_bridge/lib/nekoton/core/models/raw_contract_state.g.dart
@@ -9,14 +9,14 @@ part of 'raw_contract_state.dart';
 RawContractStateNotExists _$RawContractStateNotExistsFromJson(
         Map<String, dynamic> json) =>
     RawContractStateNotExists(
-      GenTimings.fromJson(json['timings'] as Map<String, dynamic>),
+      NotExistingContract.fromJson(json['data'] as Map<String, dynamic>),
       $type: json['type'] as String?,
     );
 
 Map<String, dynamic> _$RawContractStateNotExistsToJson(
         RawContractStateNotExists instance) =>
     <String, dynamic>{
-      'timings': instance.timings.toJson(),
+      'data': instance.data.toJson(),
       'type': instance.$type,
     };
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

# Status
**READY**

## Description
Added a new `NotExistingContract` model class that wraps `GenTimings` data to properly handle contract state when a contract doesn't exist. This fixed a JSON parse exception that was occurring with payloads like:
```json
{"type":"notExists","data":{"timings":{"genLt":"0","genUtime":1745257281}}}
```

Previously, the `notExists` state expected direct `GenTimings` objects rather than a wrapper with `data` field, causing parsing failures when processing contract state responses.

## Type of Change
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
